### PR TITLE
authors/にいて失敗したときのリンク先をhref=''に変更

### DIFF
--- a/self-made-php/authors.php
+++ b/self-made-php/authors.php
@@ -72,7 +72,7 @@
             }catch( PDOException $e ){
                 //echo( '接続失敗: ' . $e->getMessage() . '<br>' );
                 echo 'エラーが発生しました．以下のリンクから再度読み込んでください<br>';
-                echo '<a href="https://inari-dev.tk/authors" style="color:blue;">再度読み込み</a>';
+                echo '<a href="" style="color:blue;">再度読み込み</a>';
                 exit();
             }       
 ?>


### PR DESCRIPTION
例外処理の中でロールバックするためのリンクを表示していたが，それを変更しました．